### PR TITLE
feat: 完善 Java 8 + Spring Data JPA 脚手架工程

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,61 @@
 # awesome
-awesome
+
+一个基于 **Java 8 + Spring Boot + Spring Data JPA** 的多模块脚手架工程，适合作为中小型后端服务的起点。
+
+## 模块说明
+
+- `awesome-dto`：对外 API、请求对象、DTO 定义。
+- `awesome-web`：Web 层、Service 层、JPA 实体、Repository 与运行配置。
+
+## 当前脚手架能力
+
+- 基于 `Requirement` 示例演示完整的分层结构：`Controller -> Service -> Repository -> JPA Entity`。
+- 提供统一的参数校验异常返回。
+- 默认开发环境使用 H2 内存数据库，开箱即跑；生产环境可以平滑切换到 MySQL。
+- 提供基础 CRUD 与按 `status` / `creator` 过滤查询示例。
+- 测试环境内置集成测试，便于二次开发时快速回归。
+
+## Requirement API 示例
+
+### 创建需求
+
+```bash
+curl -X POST 'http://localhost:8080/awesome/requirements' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "title": "完善JPA脚手架",
+    "description": "补齐Repository与测试",
+    "priority": "HIGH",
+    "creator": "codex"
+  }'
+```
+
+### 查询需求列表
+
+```bash
+curl 'http://localhost:8080/awesome/requirements?creator=codex&status=TODO'
+```
+
+### 更新状态
+
+```bash
+curl -X PUT 'http://localhost:8080/awesome/requirements/status' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "id": 1,
+    "status": "DONE"
+  }'
+```
+
+## 启动方式
+
+```bash
+mvn clean test
+mvn -pl awesome-web spring-boot:run
+```
+
+## 后续建议
+
+- 增加 `BaseEntity`、审计字段与统一分页响应。
+- 为 `Student` 等其他领域对象继续补齐 Repository 与 JPA 映射。
+- 在生产环境中将 `application-prod.properties` 连接到 MySQL 并配合 Flyway/Liquibase 管理表结构。

--- a/awesome-dto/src/main/java/tt/heixiong/awesome/api/RequirementApi.java
+++ b/awesome-dto/src/main/java/tt/heixiong/awesome/api/RequirementApi.java
@@ -17,7 +17,8 @@ public interface RequirementApi {
     RequirementDto createRequirement(@Validated @RequestBody RequirementCreateReq req);
 
     @GetMapping
-    List<RequirementDto> listRequirements();
+    List<RequirementDto> listRequirements(@RequestParam(value = "status", required = false) String status,
+                                          @RequestParam(value = "creator", required = false) String creator);
 
     @GetMapping("/{id}")
     RequirementDto getRequirement(@PathVariable("id") Long id);

--- a/awesome-dto/src/main/java/tt/heixiong/awesome/dto/RequirementDto.java
+++ b/awesome-dto/src/main/java/tt/heixiong/awesome/dto/RequirementDto.java
@@ -3,6 +3,8 @@ package tt.heixiong.awesome.dto;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Setter
 public class RequirementDto {
@@ -19,7 +21,7 @@ public class RequirementDto {
 
     private String creator;
 
-    private Long createdAt;
+    private LocalDateTime createdAt;
 
-    private Long updatedAt;
+    private LocalDateTime updatedAt;
 }

--- a/awesome-dto/src/main/java/tt/heixiong/awesome/req/RequirementCreateReq.java
+++ b/awesome-dto/src/main/java/tt/heixiong/awesome/req/RequirementCreateReq.java
@@ -17,4 +17,6 @@ public class RequirementCreateReq {
     private String priority;
 
     private String creator;
+
+    private String status;
 }

--- a/awesome-web/pom.xml
+++ b/awesome-web/pom.xml
@@ -25,6 +25,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-config</artifactId>
         </dependency>
         <dependency>
@@ -60,6 +64,11 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/awesome-web/src/main/java/tt/heixiong/awesome/AwesomeWebApplication.java
+++ b/awesome-web/src/main/java/tt/heixiong/awesome/AwesomeWebApplication.java
@@ -3,26 +3,16 @@ package tt.heixiong.awesome;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.netflix.eureka.EnableEurekaClient;
-import org.springframework.cloud.netflix.hystrix.EnableHystrix;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableFeignClients(basePackages = "tt.heixiong.awesome.api")
+@EnableJpaAuditing
 @EnableEurekaClient
-@EnableHystrix
 public class AwesomeWebApplication {
 
-    public static void main(String[] args) throws Exception {
-/*        Student student = new Student();
-        student.setId(1L);
-        student.setName("lily");
-        student.setAge(18);
-        ObjectMapper om = new ObjectMapper();
-        try {
-            System.out.println(om.writeValueAsString(student));
-        } catch (JsonProcessingException e) {
-            e.printStackTrace();
-        }*/
+    public static void main(String[] args) {
         SpringApplication.run(AwesomeWebApplication.class, args);
-
     }
-
 }

--- a/awesome-web/src/main/java/tt/heixiong/awesome/config/GlobalExceptionHandler.java
+++ b/awesome-web/src/main/java/tt/heixiong/awesome/config/GlobalExceptionHandler.java
@@ -1,0 +1,28 @@
+package tt.heixiong.awesome.config;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public Map<String, Object> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
+        Map<String, Object> response = new LinkedHashMap<String, Object>();
+        response.put("message", "Validation failed");
+        response.put("errors", ex.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .collect(Collectors.toList()));
+        return response;
+    }
+}

--- a/awesome-web/src/main/java/tt/heixiong/awesome/domain/Requirement.java
+++ b/awesome-web/src/main/java/tt/heixiong/awesome/domain/Requirement.java
@@ -2,24 +2,47 @@ package tt.heixiong.awesome.domain;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.time.LocalDateTime;
 
 @Getter
 @Setter
+@Entity
+@Table(name = "requirements")
 public class Requirement {
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false, length = 128)
     private String title;
 
+    @Column(length = 1024)
     private String description;
 
+    @Column(length = 32)
     private String priority;
 
+    @Column(nullable = false, length = 32)
     private String status;
 
+    @Column(length = 64)
     private String creator;
 
-    private Long createdAt;
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
 
-    private Long updatedAt;
+    @UpdateTimestamp
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
 }

--- a/awesome-web/src/main/java/tt/heixiong/awesome/domain/Student.java
+++ b/awesome-web/src/main/java/tt/heixiong/awesome/domain/Student.java
@@ -2,37 +2,12 @@ package tt.heixiong.awesome.domain;
 
 import lombok.Getter;
 import lombok.Setter;
-import okhttp3.*;
-
-import java.util.Objects;
-import java.util.concurrent.TimeUnit;
 
 @Getter
 @Setter
 public class Student {
 
-    public static final Object classConstant = new Object();
-
     private Long id;
     private String name;
     private Integer age;
-
-    public static void main(String[] args) throws Exception {
-
-        OkHttpClient client = new OkHttpClient().newBuilder().connectTimeout(30, TimeUnit.SECONDS).readTimeout(30 ,TimeUnit.SECONDS).build();
-        MediaType mediaType = MediaType.parse("application/json");
-        String ss = "{\"query\":\"query queryLogs($condition: LogQueryCondition) {\\n    queryLogs(condition: $condition) {\\n        logs {\\n          serviceName\\n          serviceId\\n          serviceInstanceName\\n          serviceInstanceId\\n          endpointName\\n          endpointId\\n          traceId\\n          timestamp\\n          contentType\\n          content\\n          tags {\\n            key\\n            value\\n          }\\n        }\\n        total\\n    }}\",\"variables\":{\"condition\":{\"serviceId\":\"Y2FsbGJhY2s=.1\",\"keywordsOfContent\":[\"" + "83c291659fec43ec8a4ebbf22b662f26.5977.16700530827327707:rent.dcentralize.room.add" +  "\"],\"excludingKeywordsOfContent\":[],\"tags\":[],\"paging\":{\"pageNum\":\"1\",\"pageSize\":22,\"needTotal\":true},\"queryDuration\":{\"start\":\"2022-11-26 162630\",\"end\":\"2022-12-03 162630\",\"step\":\"SECOND\"}}}}";
-        System.out.println("网关请求：" + ss);
-        RequestBody body = RequestBody.create(ss, mediaType);
-        Request request = new Request.Builder()
-                .url("https://trace.ebaas.com/graphql")
-                .method("POST", body)
-                .addHeader("Content-Type", "application/json")
-                .build();
-        Response response = client.newCall(request).execute();
-        System.out.println("响应状态码：" + response.code());
-        String resp = response.body().string();
-        System.out.println("网关响应结果：" + Objects.requireNonNull(resp));
-    }
-
 }

--- a/awesome-web/src/main/java/tt/heixiong/awesome/repository/RequirementRepository.java
+++ b/awesome-web/src/main/java/tt/heixiong/awesome/repository/RequirementRepository.java
@@ -1,0 +1,17 @@
+package tt.heixiong.awesome.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import tt.heixiong.awesome.domain.Requirement;
+
+import java.util.List;
+
+public interface RequirementRepository extends JpaRepository<Requirement, Long> {
+
+    List<Requirement> findAllByOrderByCreatedAtDesc();
+
+    List<Requirement> findByStatus(String status);
+
+    List<Requirement> findByCreator(String creator);
+
+    List<Requirement> findByStatusAndCreator(String status, String creator);
+}

--- a/awesome-web/src/main/java/tt/heixiong/awesome/service/RequirementService.java
+++ b/awesome-web/src/main/java/tt/heixiong/awesome/service/RequirementService.java
@@ -3,16 +3,17 @@ package tt.heixiong.awesome.service;
 import tt.heixiong.awesome.domain.Requirement;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface RequirementService {
 
     Requirement createRequirement(Requirement requirement);
 
-    List<Requirement> listRequirements();
+    List<Requirement> listRequirements(String status, String creator);
 
-    Requirement getRequirement(Long id);
+    Optional<Requirement> getRequirement(Long id);
 
-    Requirement updateRequirementStatus(Long id, String status);
+    Optional<Requirement> updateRequirementStatus(Long id, String status);
 
     void deleteRequirement(Long id);
 }

--- a/awesome-web/src/main/java/tt/heixiong/awesome/service/RequirementServiceImpl.java
+++ b/awesome-web/src/main/java/tt/heixiong/awesome/service/RequirementServiceImpl.java
@@ -1,56 +1,66 @@
 package tt.heixiong.awesome.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 import tt.heixiong.awesome.domain.Requirement;
+import tt.heixiong.awesome.repository.RequirementRepository;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.Optional;
 
 @Service
+@Transactional
 public class RequirementServiceImpl implements RequirementService {
 
-    private final AtomicLong idGenerator = new AtomicLong(1);
+    private static final String DEFAULT_STATUS = "TODO";
 
-    private final Map<Long, Requirement> requirementStore = new ConcurrentHashMap<Long, Requirement>();
+    private final RequirementRepository requirementRepository;
+
+    public RequirementServiceImpl(RequirementRepository requirementRepository) {
+        this.requirementRepository = requirementRepository;
+    }
 
     @Override
     public Requirement createRequirement(Requirement requirement) {
-        Long currentId = idGenerator.getAndIncrement();
-        Long currentTime = System.currentTimeMillis();
-        requirement.setId(currentId);
-        requirement.setStatus(requirement.getStatus() == null ? "TODO" : requirement.getStatus());
-        requirement.setCreatedAt(currentTime);
-        requirement.setUpdatedAt(currentTime);
-        requirementStore.put(currentId, requirement);
-        return requirement;
-    }
-
-    @Override
-    public List<Requirement> listRequirements() {
-        return new ArrayList<Requirement>(requirementStore.values());
-    }
-
-    @Override
-    public Requirement getRequirement(Long id) {
-        return requirementStore.get(id);
-    }
-
-    @Override
-    public Requirement updateRequirementStatus(Long id, String status) {
-        Requirement requirement = requirementStore.get(id);
-        if (requirement == null) {
-            return null;
+        if (!StringUtils.hasText(requirement.getStatus())) {
+            requirement.setStatus(DEFAULT_STATUS);
         }
-        requirement.setStatus(status);
-        requirement.setUpdatedAt(System.currentTimeMillis());
-        return requirement;
+        return requirementRepository.save(requirement);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<Requirement> listRequirements(String status, String creator) {
+        if (StringUtils.hasText(status) && StringUtils.hasText(creator)) {
+            return requirementRepository.findByStatusAndCreator(status, creator);
+        }
+        if (StringUtils.hasText(status)) {
+            return requirementRepository.findByStatus(status);
+        }
+        if (StringUtils.hasText(creator)) {
+            return requirementRepository.findByCreator(creator);
+        }
+        return requirementRepository.findAllByOrderByCreatedAtDesc();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<Requirement> getRequirement(Long id) {
+        return requirementRepository.findById(id);
+    }
+
+    @Override
+    public Optional<Requirement> updateRequirementStatus(Long id, String status) {
+        return requirementRepository.findById(id)
+                .map(requirement -> {
+                    requirement.setStatus(status);
+                    return requirementRepository.save(requirement);
+                });
     }
 
     @Override
     public void deleteRequirement(Long id) {
-        requirementStore.remove(id);
+        requirementRepository.deleteById(id);
     }
 }

--- a/awesome-web/src/main/java/tt/heixiong/awesome/web/RequirementCtrl.java
+++ b/awesome-web/src/main/java/tt/heixiong/awesome/web/RequirementCtrl.java
@@ -1,11 +1,11 @@
 package tt.heixiong.awesome.web;
 
 import org.springframework.beans.BeanUtils;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
-import org.springframework.stereotype.Controller;
-import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 import tt.heixiong.awesome.api.RequirementApi;
 import tt.heixiong.awesome.domain.Requirement;
@@ -14,54 +14,56 @@ import tt.heixiong.awesome.req.RequirementCreateReq;
 import tt.heixiong.awesome.req.RequirementUpdateStatusReq;
 import tt.heixiong.awesome.service.RequirementService;
 
-import java.util.ArrayList;
+import javax.validation.Valid;
 import java.util.List;
+import java.util.stream.Collectors;
 
-@Controller
+@RestController
 @ResponseBody
 public class RequirementCtrl implements RequirementApi {
 
-    @Autowired
-    private RequirementService requirementService;
+    private final RequirementService requirementService;
+
+    public RequirementCtrl(RequirementService requirementService) {
+        this.requirementService = requirementService;
+    }
 
     @Override
-    public RequirementDto createRequirement(@Validated @RequestBody RequirementCreateReq req) {
+    public RequirementDto createRequirement(@Valid @RequestBody RequirementCreateReq req) {
         Requirement requirement = new Requirement();
         requirement.setTitle(req.getTitle());
         requirement.setDescription(req.getDescription());
         requirement.setPriority(req.getPriority());
         requirement.setCreator(req.getCreator());
+        requirement.setStatus(req.getStatus());
         return toDto(requirementService.createRequirement(requirement));
     }
 
     @Override
-    public List<RequirementDto> listRequirements() {
-        List<Requirement> requirements = requirementService.listRequirements();
-        List<RequirementDto> result = new ArrayList<RequirementDto>();
-        requirements.forEach(r -> result.add(toDto(r)));
-        return result;
+    public List<RequirementDto> listRequirements(@RequestParam(value = "status", required = false) String status,
+                                                 @RequestParam(value = "creator", required = false) String creator) {
+        return requirementService.listRequirements(status, creator)
+                .stream()
+                .map(this::toDto)
+                .collect(Collectors.toList());
     }
 
     @Override
-    public RequirementDto getRequirement(@PathVariable("id") Long id) {
-        Requirement requirement = requirementService.getRequirement(id);
-        if (requirement == null) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Requirement not found");
-        }
-        return toDto(requirement);
+    public RequirementDto getRequirement(Long id) {
+        return requirementService.getRequirement(id)
+                .map(this::toDto)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Requirement not found"));
     }
 
     @Override
-    public RequirementDto updateRequirementStatus(@Validated @RequestBody RequirementUpdateStatusReq req) {
-        Requirement requirement = requirementService.updateRequirementStatus(req.getId(), req.getStatus());
-        if (requirement == null) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Requirement not found");
-        }
-        return toDto(requirement);
+    public RequirementDto updateRequirementStatus(@Valid @RequestBody RequirementUpdateStatusReq req) {
+        return requirementService.updateRequirementStatus(req.getId(), req.getStatus())
+                .map(this::toDto)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Requirement not found"));
     }
 
     @Override
-    public void deleteRequirement(@PathVariable("id") Long id) {
+    public void deleteRequirement(Long id) {
         requirementService.deleteRequirement(id);
     }
 

--- a/awesome-web/src/main/resources/application-dev.properties
+++ b/awesome-web/src/main/resources/application-dev.properties
@@ -3,3 +3,12 @@ eureka.client.serviceUrl.defaultZone=http://localhost:8761/eureka/
 #eureka.client.serviceUrl.defaultZone=http://eureka-server:8761/eureka/
 eureka.client.fetch-registry=true
 eureka.client.register-with-eureka=true
+
+spring.datasource.url=jdbc:h2:mem:awesome;MODE=MYSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=false
+spring.jpa.properties.hibernate.format_sql=true
+spring.h2.console.enabled=true

--- a/awesome-web/src/main/resources/application.properties
+++ b/awesome-web/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 spring.profiles.active=dev
 server.servlet.context-path=/awesome
+spring.jpa.open-in-view=false

--- a/awesome-web/src/test/java/tt/heixiong/awesome/AwesomeWebApplicationTests.java
+++ b/awesome-web/src/test/java/tt/heixiong/awesome/AwesomeWebApplicationTests.java
@@ -1,42 +1,47 @@
 package tt.heixiong.awesome;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import okhttp3.*;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
 
-import java.util.Objects;
-import java.util.concurrent.TimeUnit;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
 public class AwesomeWebApplicationTests {
 
+    @Autowired
+    private MockMvc mockMvc;
+
     @Test
-    public void contextLoads() {
+    public void requirementCrudFlowWorks() throws Exception {
+        mockMvc.perform(post("/requirements")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"title\":\"补全JPA脚手架\",\"description\":\"接入Spring Data JPA\",\"priority\":\"HIGH\",\"creator\":\"codex\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").isNumber())
+                .andExpect(jsonPath("$.status").value("TODO"));
+
+        mockMvc.perform(get("/requirements").param("creator", "codex"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].title").value("补全JPA脚手架"));
+
+        mockMvc.perform(put("/requirements/status")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"id\":1,\"status\":\"DONE\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("DONE"));
     }
-
-    public static void main(String[] args) throws Exception {
-
-        OkHttpClient client = new OkHttpClient().newBuilder().connectTimeout(30, TimeUnit.SECONDS).readTimeout(30 ,TimeUnit.SECONDS).build();
-        MediaType mediaType = MediaType.parse("application/json");
-        String ss = "{\"query\":\"query queryLogs($condition: LogQueryCondition) {\\n    queryLogs(condition: $condition) {\\n        logs {\\n          serviceName\\n          serviceId\\n          serviceInstanceName\\n          serviceInstanceId\\n          endpointName\\n          endpointId\\n          traceId\\n          timestamp\\n          contentType\\n          content\\n          tags {\\n            key\\n            value\\n          }\\n        }\\n        total\\n    }}\",\"variables\":{\"condition\":{\"serviceId\":\"Y2FsbGJhY2s=.1\",\"keywordsOfContent\":[\"" + "83c291659fec43ec8a4ebbf22b662f26.5977.16700530827327707:rent.dcentralize.room.add" +  "\"],\"excludingKeywordsOfContent\":[],\"tags\":[],\"paging\":{\"pageNum\":\"1\",\"pageSize\":22,\"needTotal\":true},\"queryDuration\":{\"start\":\"2022-11-26 162630\",\"end\":\"2022-12-03 162630\",\"step\":\"SECOND\"}}}}";
-        System.out.println("网关请求：" + ss);
-        RequestBody body = RequestBody.create(ss, mediaType);
-        Request request = new Request.Builder()
-                .url("https://trace.ebaas.com/graphql")
-                .method("POST", body)
-                .addHeader("Content-Type", "application/json")
-                .build();
-        Response response = client.newCall(request).execute();
-        System.out.println("响应状态码：" + response.code());
-        Assert.assertTrue(response.isSuccessful());
-        String resp = response.body().string();
-        System.out.println("网关响应结果：" + Objects.requireNonNull(resp));
-    }
-
-
 }

--- a/awesome-web/src/test/resources/application-test.properties
+++ b/awesome-web/src/test/resources/application-test.properties
@@ -1,0 +1,10 @@
+spring.application.name=awesome-test
+server.servlet.context-path=
+eureka.client.enabled=false
+spring.cloud.discovery.enabled=false
+spring.datasource.url=jdbc:h2:mem:awesome-test;MODE=MYSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.show-sql=false


### PR DESCRIPTION
### Motivation

- 将示例从内存 `Map` 升级为可实际运行的 Spring Data JPA 分层脚手架以便后续扩展。  
- 提供本地可启动的开发/测试配置（H2）和集成测试，降低上手门槛。  
- 清理示例代码中的噪声并统一参数校验错误返回，提升可用性和可维护性。  

### Description

- 将 `Requirement` 改为 JPA 实体并使用 `LocalDateTime` 与 `@CreationTimestamp`/`@UpdateTimestamp` 表示审计字段，更新对应 DTO。  
- 新增 `RequirementRepository`（`JpaRepository`）并将 `RequirementServiceImpl` 从内存实现替换为基于 `RequirementRepository` 的事务性实现，新增按 `status` / `creator` 的查询方法。  
- 重构 Controller 为 `@RestController` 并使用构造器注入、校验注解；新增 `GlobalExceptionHandler` 返回统一的校验错误信息。  
- 更新 `awesome-web/pom.xml` 增加 `spring-boot-starter-data-jpa` 与 `h2` 依赖，补充 `application-dev.properties`/`application-test.properties`（H2 配置）、启用 Feign 与 JPA 审计，并移除 `Student` 中的无关网络示例代码，更新 `README.md` 与 API 示例。  

### Testing

- 新增基于 `MockMvc` 的集成测试 `AwesomeWebApplicationTests#requirementCrudFlowWorks` 覆盖创建、查询、更新状态流程（测试用例已加入仓库）。  
- 在本环境尝试运行 `mvn test` 失败，原因是当前环境访问 Maven Central 返回 `403` 导致依赖无法下载，自动化测试未能完成；本地或 CI 网络可访问时运行 `mvn clean test` 应能执行通过。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bb6a68878483318dafec6e166f42a2)