### PR TITLE
fix: stabilize maven repository configuration

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,34 @@
+name: Maven Build
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '8'
+          cache: maven
+
+      - name: Prepare Maven settings
+        shell: bash
+        run: |
+          mkdir -p ~/.m2
+          if [ -n "${{ secrets.MAVEN_SETTINGS_XML }}" ]; then
+            printf '%s' '${{ secrets.MAVEN_SETTINGS_XML }}' > ~/.m2/settings.xml
+          else
+            cp .mvn/settings.xml ~/.m2/settings.xml
+          fi
+
+      - name: Run tests
+        run: mvn test

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,3 @@
+--settings=.mvn/settings.xml
+-B
+-ntp

--- a/.mvn/settings.corporate-example.xml
+++ b/.mvn/settings.corporate-example.xml
@@ -1,0 +1,74 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <!--
+      公司/CI 环境示例：
+      - mirrorOf 使用 *，将所有依赖统一收敛到公司私服（Nexus / Artifactory）。
+      - 如需 HTTP/HTTPS 代理，请在 proxies 节点显式配置，并补齐 nonProxyHosts。
+      - credentials 推荐由 ~/.m2/settings-security.xml、CI Secret 或宿主机注入。
+    -->
+    <servers>
+        <server>
+            <id>company-maven</id>
+            <username>${env.MAVEN_REPO_USERNAME}</username>
+            <password>${env.MAVEN_REPO_PASSWORD}</password>
+        </server>
+    </servers>
+
+    <mirrors>
+        <mirror>
+            <id>company-maven</id>
+            <name>Company Maven Repository</name>
+            <url>https://nexus.example.com/repository/maven-public/</url>
+            <mirrorOf>*</mirrorOf>
+        </mirror>
+    </mirrors>
+
+    <profiles>
+        <profile>
+            <id>company-repositories</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <repositories>
+                <repository>
+                    <id>company-maven</id>
+                    <name>Company Maven Repository</name>
+                    <url>https://nexus.example.com/repository/maven-public/</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </repository>
+            </repositories>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>company-maven</id>
+                    <name>Company Maven Repository</name>
+                    <url>https://nexus.example.com/repository/maven-public/</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </pluginRepository>
+            </pluginRepositories>
+        </profile>
+    </profiles>
+
+    <!--
+    <proxies>
+        <proxy>
+            <id>corp-proxy</id>
+            <active>true</active>
+            <protocol>http</protocol>
+            <host>proxy.example.com</host>
+            <port>8080</port>
+            <nonProxyHosts>localhost|127.*|*.local|nexus.example.com</nonProxyHosts>
+        </proxy>
+    </proxies>
+    -->
+</settings>

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -1,0 +1,53 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <!--
+      项目级 Maven settings：
+      1. 避免依赖开发机 ~/.m2/settings.xml 中的代理/镜像污染当前仓库。
+      2. 默认直连 Maven Central，适合无代理或可直接访问外网的环境。
+      3. 若公司网络要求统一私服，请参考 settings.corporate-example.xml 覆盖使用。
+    -->
+    <mirrors>
+        <mirror>
+            <id>central</id>
+            <name>Project default Maven Central mirror</name>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <mirrorOf>central</mirrorOf>
+        </mirror>
+    </mirrors>
+
+    <profiles>
+        <profile>
+            <id>project-default-repositories</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <repositories>
+                <repository>
+                    <id>central</id>
+                    <name>Maven Central</name>
+                    <url>https://repo.maven.apache.org/maven2</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                </repository>
+            </repositories>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>central</id>
+                    <name>Maven Central</name>
+                    <url>https://repo.maven.apache.org/maven2</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                </pluginRepository>
+            </pluginRepositories>
+        </profile>
+    </profiles>
+</settings>

--- a/README.md
+++ b/README.md
@@ -47,6 +47,46 @@ curl -X PUT 'http://localhost:8080/awesome/requirements/status' \
   }'
 ```
 
+## 构建链路与 Maven 仓库约定
+
+项目现在默认通过 `.mvn/maven.config` 强制使用仓库内的 `.mvn/settings.xml`，避免开发机 `~/.m2/settings.xml` 中遗留的代理或镜像配置污染当前构建。
+
+### 本地开发（默认）
+
+适用于可以直接访问公共 Maven 仓库的环境：
+
+```bash
+mvn clean test
+mvn -pl awesome-web spring-boot:run
+```
+
+### 公司网络 / CI（推荐统一私服）
+
+如果公司网络必须通过 Nexus / Artifactory 访问依赖，请按下面步骤配置：
+
+1. 复制示例配置：
+   ```bash
+   cp .mvn/settings.corporate-example.xml ~/.m2/settings.xml
+   ```
+2. 将 `https://nexus.example.com/repository/maven-public/` 替换为公司的 Maven 私服地址。
+3. 如私服需要鉴权，注入 `MAVEN_REPO_USERNAME` / `MAVEN_REPO_PASSWORD`。
+4. 如必须走 HTTP/HTTPS 代理，请在 `proxies` 节点中显式配置，并把公司私服加入 `nonProxyHosts`，避免再次出现 `403 Forbidden`。
+
+### CI 约定
+
+仓库内新增了 `.github/workflows/maven.yml`：
+
+- 优先读取 `MAVEN_SETTINGS_XML` Secret 作为 CI 专用 `settings.xml`。
+- 未配置 Secret 时，回退到仓库内的 `.mvn/settings.xml`。
+- 统一执行 `mvn test`，保证本地与 CI 的入口一致。
+
+### 构建前置要求
+
+- JDK：`8`
+- Maven：`3.8+`（本地验证使用 `3.9.10`）
+- 默认测试数据库：H2（测试/开发环境）
+- 如果 `~/.m2/settings.xml` 中存在代理或镜像，请优先检查是否误拦截了 `repo.maven.apache.org` 或公司私服
+
 ## 启动方式
 
 ```bash


### PR DESCRIPTION
### Motivation

- Prevent builds from inheriting broken user-level `~/.m2/settings.xml` (proxy/mirror) that caused `403 Forbidden` when Maven tried to fetch Spring dependency BOMs. 
- Provide a clear, reproducible repository policy for local, corporate and CI environments so dependency resolution is predictable. 
- Add a simple CI workflow and documentation so local and GitHub Actions builds use the same settings and failure modes are easier to diagnose.

### Description

- Add project-local Maven settings at `.mvn/settings.xml` that defaults to direct Maven Central access and a project `maven.config` to force use of that settings file. 
- Add `.mvn/settings.corporate-example.xml` as a documented template for routing dependencies through a company Nexus/Artifactory (mirrorOf=`*`) with placeholders for credentials and proxy guidance. 
- Add GitHub Actions workflow `.github/workflows/maven.yml` that prefers a `MAVEN_SETTINGS_XML` secret and falls back to the repository `.mvn/settings.xml`, and runs `mvn test`. 
- Update `README.md` with a "Build chain & Maven repository conventions" section that documents local vs corporate/CI setup steps, pre-requisites (JDK/Maven) and troubleshooting advice for `403`/proxy issues. 

### Testing

- Validated XML syntax of the added settings files using Python `xml.etree.ElementTree.parse`, which succeeded for both `.mvn/settings.xml` and `.mvn/settings.corporate-example.xml`. 
- Verified project-level Maven settings are used by creating `.mvn/maven.config` and running Maven commands, which removed the original proxy-driven `403` but resulted in a `network unreachable` error when attempting to download external BOMs in the current container environment. 
- Ran `mvn -q help:effective-settings` / `mvn test` attempts to confirm behavior; these runs show the project now enforces the repository settings but full dependency download still requires a reachable mirror or corporate proxy in the environment (tests therefore fail to download dependencies in this isolated environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bb94b3ad5c83318290c2e2e8487e99)