### PR TITLE
feat: unify API response envelope and exception handling

### DIFF
--- a/awesome-dto/src/main/java/tt/heixiong/awesome/api/RequirementApi.java
+++ b/awesome-dto/src/main/java/tt/heixiong/awesome/api/RequirementApi.java
@@ -3,6 +3,7 @@ package tt.heixiong.awesome.api;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import tt.heixiong.awesome.common.ApiResponse;
 import tt.heixiong.awesome.dto.RequirementDto;
 import tt.heixiong.awesome.req.RequirementCreateReq;
 import tt.heixiong.awesome.req.RequirementUpdateStatusReq;
@@ -14,18 +15,18 @@ import java.util.List;
 public interface RequirementApi {
 
     @PostMapping
-    RequirementDto createRequirement(@Validated @RequestBody RequirementCreateReq req);
+    ApiResponse<RequirementDto> createRequirement(@Validated @RequestBody RequirementCreateReq req);
 
     @GetMapping
-    List<RequirementDto> listRequirements(@RequestParam(value = "status", required = false) String status,
-                                          @RequestParam(value = "creator", required = false) String creator);
+    ApiResponse<List<RequirementDto>> listRequirements(@RequestParam(value = "status", required = false) String status,
+                                                       @RequestParam(value = "creator", required = false) String creator);
 
     @GetMapping("/{id}")
-    RequirementDto getRequirement(@PathVariable("id") Long id);
+    ApiResponse<RequirementDto> getRequirement(@PathVariable("id") Long id);
 
     @PutMapping("/status")
-    RequirementDto updateRequirementStatus(@Validated @RequestBody RequirementUpdateStatusReq req);
+    ApiResponse<RequirementDto> updateRequirementStatus(@Validated @RequestBody RequirementUpdateStatusReq req);
 
     @DeleteMapping("/{id}")
-    void deleteRequirement(@PathVariable("id") Long id);
+    ApiResponse<Void> deleteRequirement(@PathVariable("id") Long id);
 }

--- a/awesome-dto/src/main/java/tt/heixiong/awesome/common/ApiResponse.java
+++ b/awesome-dto/src/main/java/tt/heixiong/awesome/common/ApiResponse.java
@@ -1,0 +1,31 @@
+package tt.heixiong.awesome.common;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class ApiResponse<T> {
+
+    private final String code;
+    private final String message;
+    private final T data;
+    private final String traceId;
+    private final LocalDateTime timestamp;
+
+    private ApiResponse(String code, String message, T data, String traceId, LocalDateTime timestamp) {
+        this.code = code;
+        this.message = message;
+        this.data = data;
+        this.traceId = traceId;
+        this.timestamp = timestamp;
+    }
+
+    public static <T> ApiResponse<T> success(T data, String traceId) {
+        return new ApiResponse<T>("SUCCESS", "OK", data, traceId, LocalDateTime.now());
+    }
+
+    public static <T> ApiResponse<T> failure(String code, String message, T data, String traceId) {
+        return new ApiResponse<T>(code, message, data, traceId, LocalDateTime.now());
+    }
+}

--- a/awesome-web/src/main/java/tt/heixiong/awesome/config/GlobalExceptionHandler.java
+++ b/awesome-web/src/main/java/tt/heixiong/awesome/config/GlobalExceptionHandler.java
@@ -1,28 +1,92 @@
 package tt.heixiong.awesome.config;
 
+import feign.FeignException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.server.ResponseStatusException;
+import tt.heixiong.awesome.common.ApiResponse;
+import tt.heixiong.awesome.exception.BusinessException;
 
+import javax.servlet.http.HttpServletRequest;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    private static final String TRACE_ID_HEADER = "X-Trace-Id";
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public Map<String, Object> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
-        Map<String, Object> response = new LinkedHashMap<String, Object>();
-        response.put("message", "Validation failed");
-        response.put("errors", ex.getBindingResult()
+    public ResponseEntity<ApiResponse<Map<String, Object>>> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex,
+                                                                                                  HttpServletRequest request) {
+        Map<String, Object> errors = new LinkedHashMap<String, Object>();
+        errors.put("errors", ex.getBindingResult()
                 .getFieldErrors()
                 .stream()
                 .map(error -> error.getField() + ": " + error.getDefaultMessage())
                 .collect(Collectors.toList()));
-        return response;
+        return buildResponse(HttpStatus.BAD_REQUEST, "VALIDATION_FAILED", "Validation failed", errors, request);
+    }
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ApiResponse<Map<String, Object>>> handleBusinessException(BusinessException ex,
+                                                                                     HttpServletRequest request) {
+        return buildResponse(ex.getHttpStatus(), ex.getCode(), ex.getMessage(), null, request);
+    }
+
+    @ExceptionHandler({MissingServletRequestParameterException.class, MethodArgumentTypeMismatchException.class})
+    public ResponseEntity<ApiResponse<Map<String, Object>>> handleBadRequest(Exception ex, HttpServletRequest request) {
+        return buildResponse(HttpStatus.BAD_REQUEST, "BAD_REQUEST", ex.getMessage(), null, request);
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ApiResponse<Map<String, Object>>> handleDataIntegrityViolationException(DataIntegrityViolationException ex,
+                                                                                                   HttpServletRequest request) {
+        return buildResponse(HttpStatus.CONFLICT, "DATA_INTEGRITY_VIOLATION", "Data integrity violation", null, request);
+    }
+
+    @ExceptionHandler(FeignException.class)
+    public ResponseEntity<ApiResponse<Map<String, Object>>> handleFeignException(FeignException ex,
+                                                                                  HttpServletRequest request) {
+        return buildResponse(HttpStatus.BAD_GATEWAY, "REMOTE_CALL_FAILED", "Remote call failed", null, request);
+    }
+
+    @ExceptionHandler(ResponseStatusException.class)
+    public ResponseEntity<ApiResponse<Map<String, Object>>> handleResponseStatusException(ResponseStatusException ex,
+                                                                                           HttpServletRequest request) {
+        return buildResponse(ex.getStatus(), "HTTP_STATUS_ERROR", ex.getReason(), null, request);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Map<String, Object>>> handleException(Exception ex, HttpServletRequest request) {
+        return buildResponse(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "Internal server error", null, request);
+    }
+
+    private ResponseEntity<ApiResponse<Map<String, Object>>> buildResponse(HttpStatus status,
+                                                                           String code,
+                                                                           String message,
+                                                                           Map<String, Object> data,
+                                                                           HttpServletRequest request) {
+        return ResponseEntity.status(status)
+                .body(ApiResponse.failure(code, message, appendRequestPath(data, request), getTraceId(request)));
+    }
+
+    private Map<String, Object> appendRequestPath(Map<String, Object> data, HttpServletRequest request) {
+        Map<String, Object> body = data == null ? new LinkedHashMap<String, Object>() : new LinkedHashMap<String, Object>(data);
+        body.put("path", request.getRequestURI());
+        return body;
+    }
+
+    private String getTraceId(HttpServletRequest request) {
+        String traceId = request.getHeader(TRACE_ID_HEADER);
+        return traceId != null && traceId.trim().length() > 0 ? traceId : UUID.randomUUID().toString();
     }
 }

--- a/awesome-web/src/main/java/tt/heixiong/awesome/exception/BusinessException.java
+++ b/awesome-web/src/main/java/tt/heixiong/awesome/exception/BusinessException.java
@@ -1,0 +1,23 @@
+package tt.heixiong.awesome.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class BusinessException extends RuntimeException {
+
+    private final String code;
+    private final HttpStatus httpStatus;
+
+    public BusinessException(String code, String message, HttpStatus httpStatus) {
+        super(message);
+        this.code = code;
+        this.httpStatus = httpStatus;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+}

--- a/awesome-web/src/main/java/tt/heixiong/awesome/exception/RemoteCallException.java
+++ b/awesome-web/src/main/java/tt/heixiong/awesome/exception/RemoteCallException.java
@@ -1,0 +1,10 @@
+package tt.heixiong.awesome.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class RemoteCallException extends BusinessException {
+
+    public RemoteCallException(String message) {
+        super("REMOTE_CALL_FAILED", message, HttpStatus.BAD_GATEWAY);
+    }
+}

--- a/awesome-web/src/main/java/tt/heixiong/awesome/exception/ResourceNotFoundException.java
+++ b/awesome-web/src/main/java/tt/heixiong/awesome/exception/ResourceNotFoundException.java
@@ -1,0 +1,10 @@
+package tt.heixiong.awesome.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class ResourceNotFoundException extends BusinessException {
+
+    public ResourceNotFoundException(String message) {
+        super("RESOURCE_NOT_FOUND", message, HttpStatus.NOT_FOUND);
+    }
+}

--- a/awesome-web/src/main/java/tt/heixiong/awesome/service/RequirementServiceImpl.java
+++ b/awesome-web/src/main/java/tt/heixiong/awesome/service/RequirementServiceImpl.java
@@ -1,9 +1,11 @@
 package tt.heixiong.awesome.service;
 
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import tt.heixiong.awesome.domain.Requirement;
+import tt.heixiong.awesome.exception.ResourceNotFoundException;
 import tt.heixiong.awesome.repository.RequirementRepository;
 
 import java.util.List;
@@ -61,6 +63,10 @@ public class RequirementServiceImpl implements RequirementService {
 
     @Override
     public void deleteRequirement(Long id) {
-        requirementRepository.deleteById(id);
+        try {
+            requirementRepository.deleteById(id);
+        } catch (EmptyResultDataAccessException ex) {
+            throw new ResourceNotFoundException("Requirement not found");
+        }
     }
 }

--- a/awesome-web/src/main/java/tt/heixiong/awesome/web/RequirementCtrl.java
+++ b/awesome-web/src/main/java/tt/heixiong/awesome/web/RequirementCtrl.java
@@ -1,75 +1,86 @@
 package tt.heixiong.awesome.web;
 
 import org.springframework.beans.BeanUtils;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.server.ResponseStatusException;
 import tt.heixiong.awesome.api.RequirementApi;
+import tt.heixiong.awesome.common.ApiResponse;
 import tt.heixiong.awesome.domain.Requirement;
 import tt.heixiong.awesome.dto.RequirementDto;
+import tt.heixiong.awesome.exception.ResourceNotFoundException;
 import tt.heixiong.awesome.req.RequirementCreateReq;
 import tt.heixiong.awesome.req.RequirementUpdateStatusReq;
 import tt.heixiong.awesome.service.RequirementService;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @RestController
-@ResponseBody
 public class RequirementCtrl implements RequirementApi {
 
-    private final RequirementService requirementService;
+    private static final String TRACE_ID_HEADER = "X-Trace-Id";
 
-    public RequirementCtrl(RequirementService requirementService) {
+    private final RequirementService requirementService;
+    private final HttpServletRequest request;
+
+    public RequirementCtrl(RequirementService requirementService, HttpServletRequest request) {
         this.requirementService = requirementService;
+        this.request = request;
     }
 
     @Override
-    public RequirementDto createRequirement(@Valid @RequestBody RequirementCreateReq req) {
+    public ApiResponse<RequirementDto> createRequirement(@Valid @RequestBody RequirementCreateReq req) {
         Requirement requirement = new Requirement();
         requirement.setTitle(req.getTitle());
         requirement.setDescription(req.getDescription());
         requirement.setPriority(req.getPriority());
         requirement.setCreator(req.getCreator());
         requirement.setStatus(req.getStatus());
-        return toDto(requirementService.createRequirement(requirement));
+        return ApiResponse.success(toDto(requirementService.createRequirement(requirement)), getTraceId());
     }
 
     @Override
-    public List<RequirementDto> listRequirements(@RequestParam(value = "status", required = false) String status,
-                                                 @RequestParam(value = "creator", required = false) String creator) {
-        return requirementService.listRequirements(status, creator)
+    public ApiResponse<List<RequirementDto>> listRequirements(@RequestParam(value = "status", required = false) String status,
+                                                              @RequestParam(value = "creator", required = false) String creator) {
+        List<RequirementDto> requirements = requirementService.listRequirements(status, creator)
                 .stream()
                 .map(this::toDto)
                 .collect(Collectors.toList());
+        return ApiResponse.success(requirements, getTraceId());
     }
 
     @Override
-    public RequirementDto getRequirement(Long id) {
-        return requirementService.getRequirement(id)
-                .map(this::toDto)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Requirement not found"));
+    public ApiResponse<RequirementDto> getRequirement(Long id) {
+        Requirement requirement = requirementService.getRequirement(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Requirement not found"));
+        return ApiResponse.success(toDto(requirement), getTraceId());
     }
 
     @Override
-    public RequirementDto updateRequirementStatus(@Valid @RequestBody RequirementUpdateStatusReq req) {
-        return requirementService.updateRequirementStatus(req.getId(), req.getStatus())
-                .map(this::toDto)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Requirement not found"));
+    public ApiResponse<RequirementDto> updateRequirementStatus(@Valid @RequestBody RequirementUpdateStatusReq req) {
+        Requirement requirement = requirementService.updateRequirementStatus(req.getId(), req.getStatus())
+                .orElseThrow(() -> new ResourceNotFoundException("Requirement not found"));
+        return ApiResponse.success(toDto(requirement), getTraceId());
     }
 
     @Override
-    public void deleteRequirement(Long id) {
+    public ApiResponse<Void> deleteRequirement(Long id) {
         requirementService.deleteRequirement(id);
+        return ApiResponse.success(null, getTraceId());
     }
 
     private RequirementDto toDto(Requirement requirement) {
         RequirementDto dto = new RequirementDto();
         BeanUtils.copyProperties(requirement, dto);
         return dto;
+    }
+
+    private String getTraceId() {
+        String traceId = request.getHeader(TRACE_ID_HEADER);
+        return traceId != null && traceId.trim().length() > 0 ? traceId : UUID.randomUUID().toString();
     }
 }

--- a/awesome-web/src/test/java/tt/heixiong/awesome/AwesomeWebApplicationTests.java
+++ b/awesome-web/src/test/java/tt/heixiong/awesome/AwesomeWebApplicationTests.java
@@ -10,6 +10,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -29,19 +30,53 @@ public class AwesomeWebApplicationTests {
     public void requirementCrudFlowWorks() throws Exception {
         mockMvc.perform(post("/requirements")
                         .contentType(MediaType.APPLICATION_JSON)
+                        .header("X-Trace-Id", "trace-create")
                         .content("{\"title\":\"补全JPA脚手架\",\"description\":\"接入Spring Data JPA\",\"priority\":\"HIGH\",\"creator\":\"codex\"}"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.id").isNumber())
-                .andExpect(jsonPath("$.status").value("TODO"));
+                .andExpect(jsonPath("$.code").value("SUCCESS"))
+                .andExpect(jsonPath("$.message").value("OK"))
+                .andExpect(jsonPath("$.traceId").value("trace-create"))
+                .andExpect(jsonPath("$.data.id").isNumber())
+                .andExpect(jsonPath("$.data.status").value("TODO"));
 
         mockMvc.perform(get("/requirements").param("creator", "codex"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].title").value("补全JPA脚手架"));
+                .andExpect(jsonPath("$.code").value("SUCCESS"))
+                .andExpect(jsonPath("$.data[0].title").value("补全JPA脚手架"));
 
         mockMvc.perform(put("/requirements/status")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"id\":1,\"status\":\"DONE\"}"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status").value("DONE"));
+                .andExpect(jsonPath("$.code").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.status").value("DONE"));
+    }
+
+    @Test
+    public void validationErrorsUseUnifiedEnvelope() throws Exception {
+        mockMvc.perform(post("/requirements")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"title\":\"\",\"creator\":\"codex\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_FAILED"))
+                .andExpect(jsonPath("$.message").value("Validation failed"))
+                .andExpect(jsonPath("$.data.errors[0]").value("title: must not be blank"))
+                .andExpect(jsonPath("$.data.path").value("/requirements"));
+    }
+
+    @Test
+    public void missingResourceUsesUnifiedEnvelope() throws Exception {
+        mockMvc.perform(get("/requirements/999"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("RESOURCE_NOT_FOUND"))
+                .andExpect(jsonPath("$.message").value("Requirement not found"))
+                .andExpect(jsonPath("$.data.path").value("/requirements/999"));
+    }
+
+    @Test
+    public void deleteMissingResourceUsesUnifiedEnvelope() throws Exception {
+        mockMvc.perform(delete("/requirements/999"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("RESOURCE_NOT_FOUND"));
     }
 }


### PR DESCRIPTION
### Motivation

- Provide a single, consistent API response envelope and traceability fields so controllers always return `code`/`message`/`data`/`traceId`/`timestamp` for easier front-end integration and troubleshooting. 
- Centralize exception handling to cover validation, business errors, resource-not-found, data integrity, remote-call failures and unexpected system errors so error shapes are predictable across the service.

### Description

- Add a generic response envelope `tt.heixiong.awesome.common.ApiResponse<T>` and switch the `RequirementApi` contract to return `ApiResponse<...>` instead of raw DTOs. 
- Update `RequirementCtrl` to wrap responses with `ApiResponse.success(...)`, include a propagated header `X-Trace-Id` (or generate a UUID) and return the unified shape for create/list/get/update/delete operations. 
- Introduce domain exception types `BusinessException`, `ResourceNotFoundException`, and `RemoteCallException` under `awesome-web/src/main/java/tt/heixiong/awesome/exception`. 
- Replace the old `GlobalExceptionHandler` implementation with a handler that builds `ApiResponse.failure(...)` bodies and handles `MethodArgumentNotValidException`, `BusinessException`, missing/typed-parameter errors, `DataIntegrityViolationException`, Feign `FeignException`, `ResponseStatusException`, and generic `Exception`, and that appends request `path` and `traceId`. 
- Make `RequirementServiceImpl.deleteRequirement` surface missing deletes as `ResourceNotFoundException` and update tests in `awesome-web/src/test/java/tt/heixiong/awesome/AwesomeWebApplicationTests.java` to assert the new success/error envelopes.

### Testing

- Ran the automated test command `mvn test`, which could not complete because Maven failed to resolve Spring Boot / Spring Cloud BOM artifacts from Maven Central (HTTP 403), so the updated test suite could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bb957041a08331a2b6c706450e5ca3)